### PR TITLE
VEI-148: Build Kick Out Pages For When Intermediary Fails To Pass GG Validation

### DIFF
--- a/app/config/FrontendAppConfig.scala
+++ b/app/config/FrontendAppConfig.scala
@@ -72,4 +72,6 @@ class FrontendAppConfig @Inject()(configuration: Configuration) {
   val cacheTtl: Long = configuration.get[Long]("mongodb.timeToLiveInSeconds")
 
   val iossEnrolment: String = configuration.get[String]("ioss-enrolment")
+  
+  val intermediaryEnrolment: String = configuration.get[String]("intermediary-enrolment")
 }

--- a/app/controllers/AlreadyRegisteredController.scala
+++ b/app/controllers/AlreadyRegisteredController.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import controllers.actions._
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.AlreadyRegisteredView
+
+class AlreadyRegisteredController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: AlreadyRegisteredView
+                                     ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+}

--- a/app/controllers/AlreadyRegisteredController.scala
+++ b/app/controllers/AlreadyRegisteredController.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import controllers.actions._
@@ -9,14 +25,12 @@ import views.html.AlreadyRegisteredView
 
 class AlreadyRegisteredController @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
+                                       cc: AuthenticatedControllerComponents,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: AlreadyRegisteredView
                                      ) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad: Action[AnyContent] = (cc.actionBuilder andThen cc.identify) {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/CannotRegisterNotNiBasedBusinessController.scala
+++ b/app/controllers/CannotRegisterNotNiBasedBusinessController.scala
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
-import controllers.actions._
+import controllers.actions.*
+import pages.Waypoints
+
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -9,14 +27,12 @@ import views.html.CannotRegisterNotNiBasedBusinessView
 
 class CannotRegisterNotNiBasedBusinessController @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
+                                       cc: AuthenticatedControllerComponents,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: CannotRegisterNotNiBasedBusinessView
                                      ) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad(waypoints: Waypoints): Action[AnyContent] = (cc.actionBuilder andThen cc.identify) {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/CannotRegisterNotNiBasedBusinessController.scala
+++ b/app/controllers/CannotRegisterNotNiBasedBusinessController.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import controllers.actions._
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.CannotRegisterNotNiBasedBusinessView
+
+class CannotRegisterNotNiBasedBusinessController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: CannotRegisterNotNiBasedBusinessView
+                                     ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+}

--- a/app/controllers/ExpiredVrnDateController.scala
+++ b/app/controllers/ExpiredVrnDateController.scala
@@ -1,0 +1,23 @@
+package controllers
+
+import controllers.actions._
+import javax.inject.Inject
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
+import views.html.ExpiredVrnDateView
+
+class ExpiredVrnDateController @Inject()(
+                                       override val messagesApi: MessagesApi,
+                                       identify: IdentifierAction,
+                                       getData: DataRetrievalAction,
+                                       requireData: DataRequiredAction,
+                                       val controllerComponents: MessagesControllerComponents,
+                                       view: ExpiredVrnDateView
+                                     ) extends FrontendBaseController with I18nSupport {
+
+  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+    implicit request =>
+      Ok(view())
+  }
+}

--- a/app/controllers/ExpiredVrnDateController.scala
+++ b/app/controllers/ExpiredVrnDateController.scala
@@ -1,6 +1,24 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
-import controllers.actions._
+import controllers.actions.*
+import pages.Waypoints
+
 import javax.inject.Inject
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -9,14 +27,12 @@ import views.html.ExpiredVrnDateView
 
 class ExpiredVrnDateController @Inject()(
                                        override val messagesApi: MessagesApi,
-                                       identify: IdentifierAction,
-                                       getData: DataRetrievalAction,
-                                       requireData: DataRequiredAction,
+                                       cc: AuthenticatedControllerComponents,
                                        val controllerComponents: MessagesControllerComponents,
                                        view: ExpiredVrnDateView
                                      ) extends FrontendBaseController with I18nSupport {
 
-  def onPageLoad: Action[AnyContent] = (identify andThen getData andThen requireData) {
+  def onPageLoad(waypoints: Waypoints): Action[AnyContent] = (cc.actionBuilder andThen cc.identify) {
     implicit request =>
       Ok(view())
   }

--- a/app/controllers/actions/CheckRegistrationFilter.scala
+++ b/app/controllers/actions/CheckRegistrationFilter.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import config.FrontendAppConfig
+import logging.Logging
+import models.requests.AuthenticatedIdentifierRequest
+import play.api.mvc.Results.Redirect
+import play.api.mvc.{ActionFilter, Result}
+import utils.FutureSyntax.FutureOps
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CheckRegistrationFilter(frontendAppConfig: FrontendAppConfig)(implicit val executionContext: ExecutionContext)
+  extends ActionFilter[AuthenticatedIdentifierRequest] with Logging {
+
+  override protected def filter[A](request: AuthenticatedIdentifierRequest[A]): Future[Option[Result]] = {
+
+    if hasIntermediaryEnrolment(request) then
+      Some(Redirect(controllers.routes.AlreadyRegisteredController.onPageLoad().url)).toFuture
+    else
+      None.toFuture
+  }
+
+  private def hasIntermediaryEnrolment(request: AuthenticatedIdentifierRequest[_]): Boolean = {
+    request.enrolments.enrolments.exists(_.key == frontendAppConfig.intermediaryEnrolment)
+  }
+}

--- a/app/controllers/auth/AuthController.scala
+++ b/app/controllers/auth/AuthController.scala
@@ -33,7 +33,7 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendBaseController
 import utils.FutureSyntax.FutureOps
 import views.html.auth.{InsufficientEnrolmentsView, UnsupportedAffinityGroupView, UnsupportedAuthProviderView, UnsupportedCredentialRoleView}
 
-import java.time.{Clock, Instant}
+import java.time.{Clock, Instant, LocalDate}
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -81,16 +81,26 @@ class AuthController @Inject()(
 
         case _ =>
           registrationConnector.getVatCustomerInfo().flatMap {
+
+            case Right(vatInfo) if checkVrnExpired(vatInfo) =>
+              println("---------------- INSIDED CHECK VRN EXPIRED ------------------- ")
+              println("---------------- INSIDED CHECK VRN EXPIRED ------------------- ")
+              Redirect(controllers.routes.ExpiredVrnDateController.onPageLoad().url).toFuture
+
             case Right(vatInfo) if !isNiBasedIntermediary(vatInfo) =>
+              println("---------------- INSIDE NI BASED INterMEDIARY ------------------- ")
               Redirect(controllers.routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url).toFuture
 
             case Right(vatInfo) =>
+              println("---------------- INSIDE SUCCESSFULL Scenario ------------------- ")
+              println("---------------- INSIDE SUCCESSFULL Scenario VAT INFO!!! ------------------- " + vatInfo)
               for {
                 updatedAnswers <- Future.fromTry(answers.copy(vatInfo = Some(vatInfo)).set(VatApiCallResultQuery, VatApiCallResult.Success))
                 _ <- cc.sessionRepository.set(updatedAnswers)
               } yield Redirect(CheckVatDetailsPage.route(EmptyWaypoints).url)
 
             case _ =>
+              println("---------------- INSIDE API DOWN ------------------- ")
               for {
                 updatedAnswers <- Future.fromTry(answers.set(VatApiCallResultQuery, VatApiCallResult.Error))
                 _ <- cc.sessionRepository.set(updatedAnswers)
@@ -132,5 +142,9 @@ class AuthController @Inject()(
   private def isNiBasedIntermediary(vatCustomerInfo: VatCustomerInfo): Boolean =
     vatCustomerInfo.desAddress.postCode.exists(_.toUpperCase.startsWith("BT"))
 
-//  private def expiredVrn
+  private def checkVrnExpired(vatCustomerInfo: VatCustomerInfo): Boolean =
+    println("CHECK VRN EXPIRED VAT INFO -------------> " + vatCustomerInfo)
+    println("CHECK VRN EXPIRED -------------> " + vatCustomerInfo.deregistrationDecisionDate.exists(!_.isAfter(LocalDate.now(clock))))
+    vatCustomerInfo.deregistrationDecisionDate.exists(!_.isAfter(LocalDate.now(clock)))
+
 }

--- a/app/controllers/auth/AuthController.scala
+++ b/app/controllers/auth/AuthController.scala
@@ -21,6 +21,7 @@ import connectors.RegistrationConnector
 import controllers.actions.AuthenticatedControllerComponents
 import models.UserAnswers
 import models.checkVatDetails.VatApiCallResult
+import models.domain.VatCustomerInfo
 import pages.EmptyWaypoints
 import pages.checkVatDetails.{CheckVatDetailsPage, VatApiDownPage}
 import play.api.i18n.I18nSupport
@@ -80,6 +81,9 @@ class AuthController @Inject()(
 
         case _ =>
           registrationConnector.getVatCustomerInfo().flatMap {
+            case Right(vatInfo) if !isNiBasedIntermediary(vatInfo) =>
+              Redirect(controllers.routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url).toFuture
+
             case Right(vatInfo) =>
               for {
                 updatedAnswers <- Future.fromTry(answers.copy(vatInfo = Some(vatInfo)).set(VatApiCallResultQuery, VatApiCallResult.Success))
@@ -124,4 +128,8 @@ class AuthController @Inject()(
     implicit request =>
       Ok(unsupportedCredentialRoleView())
   }
+
+  private def isNiBasedIntermediary(vatCustomerInfo: VatCustomerInfo): Boolean =
+    vatCustomerInfo.desAddress.postCode.exists(_.toUpperCase.startsWith("BT"))
+
 }

--- a/app/controllers/auth/AuthController.scala
+++ b/app/controllers/auth/AuthController.scala
@@ -132,4 +132,5 @@ class AuthController @Inject()(
   private def isNiBasedIntermediary(vatCustomerInfo: VatCustomerInfo): Boolean =
     vatCustomerInfo.desAddress.postCode.exists(_.toUpperCase.startsWith("BT"))
 
+//  private def expiredVrn
 }

--- a/app/models/domain/VatCustomerInfo.scala
+++ b/app/models/domain/VatCustomerInfo.scala
@@ -26,7 +26,8 @@ case class VatCustomerInfo(
                             registrationDate: LocalDate,
                             organisationName: Option[String],
                             individualName: Option[String],
-                            singleMarketIndicator: Boolean
+                            singleMarketIndicator: Boolean,
+                            deregistrationDecisionDate: Option[LocalDate]
                           )
 
 object VatCustomerInfo {

--- a/app/views/AlreadyRegisteredView.scala.html
+++ b/app/views/AlreadyRegisteredView.scala.html
@@ -1,0 +1,11 @@
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("alreadyRegistered.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("alreadyRegistered.heading")</h1>
+}

--- a/app/views/AlreadyRegisteredView.scala.html
+++ b/app/views/AlreadyRegisteredView.scala.html
@@ -24,11 +24,7 @@
 
         <h1 class="govuk-heading-l">@messages("alreadyRegistered.heading")</h1>
 
-        <p class="govuk-body-m">
-          <a id="backToYourAccount" class="govuk-link">
-            @messages("alreadyRegistered.continue")
-          </a>
-        </p>
+        <p class="govuk-body">@Html(messages("alreadyRegistered.link"))</p>
     </div>
 
 }

--- a/app/views/AlreadyRegisteredView.scala.html
+++ b/app/views/AlreadyRegisteredView.scala.html
@@ -1,11 +1,34 @@
-@this(
-        layout: templates.Layout,
-        govukButton: GovukButton
-)
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(layout: templates.Layout)
 
 @()(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("alreadyRegistered.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("alreadyRegistered.heading")</h1>
+    <div class="grid-row column-two-thirds">
+
+        <h1 class="govuk-heading-l">@messages("alreadyRegistered.heading")</h1>
+
+        <p class="govuk-body-m">
+          <a id="backToYourAccount" class="govuk-link">
+            @messages("alreadyRegistered.continue")
+          </a>
+        </p>
+    </div>
+
 }

--- a/app/views/CannotRegisterNotNiBasedBusinessView.scala.html
+++ b/app/views/CannotRegisterNotNiBasedBusinessView.scala.html
@@ -1,0 +1,11 @@
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("cannotRegisterNotNiBasedBusiness.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("cannotRegisterNotNiBasedBusiness.heading")</h1>
+}

--- a/app/views/CannotRegisterNotNiBasedBusinessView.scala.html
+++ b/app/views/CannotRegisterNotNiBasedBusinessView.scala.html
@@ -1,11 +1,26 @@
-@this(
-        layout: templates.Layout,
-        govukButton: GovukButton
-)
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this(layout: templates.Layout)
 
 @()(implicit request: Request[_], messages: Messages)
 
 @layout(pageTitle = titleNoForm(messages("cannotRegisterNotNiBasedBusiness.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("cannotRegisterNotNiBasedBusiness.heading")</h1>
+    <h1 class="govuk-heading-l">@messages("cannotRegisterNotNiBasedBusiness.heading")</h1>
+
+    <p class="govuk-body">@messages("cannotRegisterNotNiBasedBusiness.p1")</p>
 }

--- a/app/views/ExpiredVrnDateView.scala.html
+++ b/app/views/ExpiredVrnDateView.scala.html
@@ -1,3 +1,19 @@
+@*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
 @this(
         layout: templates.Layout,
         govukButton: GovukButton
@@ -7,5 +23,7 @@
 
 @layout(pageTitle = titleNoForm(messages("expiredVrnDate.title"))) {
 
-    <h1 class="govuk-heading-xl">@messages("expiredVrnDate.heading")</h1>
+    <h1 class="govuk-heading-l">@messages("expiredVrnDate.heading")</h1>
+
+    <p class="govuk-body">@Html(messages("expiredVrnDate.link"))</p>
 }

--- a/app/views/ExpiredVrnDateView.scala.html
+++ b/app/views/ExpiredVrnDateView.scala.html
@@ -1,0 +1,11 @@
+@this(
+        layout: templates.Layout,
+        govukButton: GovukButton
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@layout(pageTitle = titleNoForm(messages("expiredVrnDate.title"))) {
+
+    <h1 class="govuk-heading-xl">@messages("expiredVrnDate.heading")</h1>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -55,6 +55,8 @@ GET         /registration-service-error                  controllers.checkVatDet
 
 GET        /cannot-register-not-ni-based-business        controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 
+GET        /expired-vrn-date                             controllers.ExpiredVrnDateController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+
 # Filter questions section
 GET         /ioss-intermediary-registered                controllers.filters.RegisteredForIossIntermediaryInEuController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST        /ioss-intermediary-registered                controllers.filters.RegisteredForIossIntermediaryInEuController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
@@ -90,13 +92,9 @@ POST        /remove-uk-trading-name/:index               controllers.tradingName
 GET         /remove-all-trading-names                    controllers.tradingNames.DeleteAllTradingNamesController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST        /remove-all-trading-names                    controllers.tradingNames.DeleteAllTradingNamesController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
-
-GET        /contact-details                        controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
-POST       /contact-details                        controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
+GET        /contact-details                              controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+POST       /contact-details                              controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
 
 # Other
 GET        /already-registered                           controllers.AlreadyRegisteredController.onPageLoad()
-
-
-GET        /expiredVrnDate                       controllers.ExpiredVrnDateController.onPageLoad()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -92,4 +92,4 @@ POST        /remove-all-trading-names                    controllers.tradingName
 GET        /contact-details                        controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST       /contact-details                        controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
-GET        /alreadyRegistered                       controllers.AlreadyRegisteredController.onPageLoad()
+GET        /already-registered                       controllers.AlreadyRegisteredController.onPageLoad()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -53,9 +53,11 @@ GET         /register-different-business                 controllers.checkVatDet
 
 GET         /registration-service-error                  controllers.checkVatDetails.VatApiDownController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 
-GET        /cannot-register-not-ni-based-business        controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+GET         /cannot-register-not-ni-based-business        controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 
-GET        /expired-vrn-date                             controllers.ExpiredVrnDateController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+GET         /expired-vrn-date                             controllers.ExpiredVrnDateController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+
+GET         /insufficient-enrolments                       controllers.auth.AuthController.insufficientEnrolments()
 
 # Filter questions section
 GET         /ioss-intermediary-registered                controllers.filters.RegisteredForIossIntermediaryInEuController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
@@ -92,9 +94,9 @@ POST        /remove-uk-trading-name/:index               controllers.tradingName
 GET         /remove-all-trading-names                    controllers.tradingNames.DeleteAllTradingNamesController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST        /remove-all-trading-names                    controllers.tradingNames.DeleteAllTradingNamesController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
-GET        /contact-details                              controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
-POST       /contact-details                              controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
+GET         /contact-details                              controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+POST        /contact-details                              controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
 
 # Other
-GET        /already-registered                           controllers.AlreadyRegisteredController.onPageLoad()
+GET         /already-registered                           controllers.AlreadyRegisteredController.onPageLoad()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -93,3 +93,5 @@ GET        /contact-details                        controllers.ContactDetailsCon
 POST       /contact-details                        controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
 GET        /already-registered                       controllers.AlreadyRegisteredController.onPageLoad()
+
+GET        /cannotRegisterNotNiBasedBusiness                       controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -91,3 +91,5 @@ POST        /remove-all-trading-names                    controllers.tradingName
 
 GET        /contact-details                        controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST       /contact-details                        controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
+
+GET        /alreadyRegistered                       controllers.AlreadyRegisteredController.onPageLoad()

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -53,6 +53,8 @@ GET         /register-different-business                 controllers.checkVatDet
 
 GET         /registration-service-error                  controllers.checkVatDetails.VatApiDownController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 
+GET        /cannot-register-not-ni-based-business        controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
+
 # Filter questions section
 GET         /ioss-intermediary-registered                controllers.filters.RegisteredForIossIntermediaryInEuController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST        /ioss-intermediary-registered                controllers.filters.RegisteredForIossIntermediaryInEuController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
@@ -92,6 +94,7 @@ POST        /remove-all-trading-names                    controllers.tradingName
 GET        /contact-details                        controllers.ContactDetailsController.onPageLoad(waypoints: Waypoints ?= EmptyWaypoints)
 POST       /contact-details                        controllers.ContactDetailsController.onSubmit(waypoints: Waypoints ?= EmptyWaypoints)
 
-GET        /already-registered                       controllers.AlreadyRegisteredController.onPageLoad()
 
-GET        /cannotRegisterNotNiBasedBusiness                       controllers.CannotRegisterNotNiBasedBusinessController.onPageLoad()
+# Other
+GET        /already-registered                           controllers.AlreadyRegisteredController.onPageLoad()
+

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -98,3 +98,5 @@ POST       /contact-details                        controllers.ContactDetailsCon
 # Other
 GET        /already-registered                           controllers.AlreadyRegisteredController.onPageLoad()
 
+
+GET        /expiredVrnDate                       controllers.ExpiredVrnDateController.onPageLoad()

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -119,3 +119,5 @@ features {
 }
 
 ioss-enrolment = "HMRC-IOSS-ORG"
+
+intermediary-enrolment = "HMRC-IOSS-INT"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -248,3 +248,6 @@ contactDetails.ossWarning = Any changes you make here will also update the conta
 contactDetails.ossAndIossWarning = Any changes you make here will also update the contact details in your One Stop Shop and previous Import One Stop Shop registrations.
 contactDetails.oneIossWarning = Any changes you make here will also update the contact details in your previous Import One Stop Shop registration.
 contactDetails.iossWarning = Any changes you make here will also update the contact details in all of your Import One Stop Shop registrations.
+
+alreadyRegistered.title = alreadyRegistered
+alreadyRegistered.heading = alreadyRegistered

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -257,5 +257,6 @@ cannotRegisterNotNiBasedBusiness.title = You cannot register for this service
 cannotRegisterNotNiBasedBusiness.heading = You cannot register for this service
 cannotRegisterNotNiBasedBusiness.p1 = To register as a Northern Ireland intermediary, your business trading address must be in Northern Ireland.
 
-expiredVrnDate.title = expiredVrnDate
-expiredVrnDate.heading = expiredVrnDate
+expiredVrnDate.title = The VAT number for this account is no longer valid
+expiredVrnDate.heading = The VAT number for this account is no longer valid
+expiredVrnDate.link = <a href="https://www.gov.uk/register-for-vat/how-register-for-vat" class="govuk-link">Apply for a new VAT number to use this service</a>

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -249,5 +249,6 @@ contactDetails.ossAndIossWarning = Any changes you make here will also update th
 contactDetails.oneIossWarning = Any changes you make here will also update the contact details in your previous Import One Stop Shop registration.
 contactDetails.iossWarning = Any changes you make here will also update the contact details in all of your Import One Stop Shop registrations.
 
-alreadyRegistered.title = alreadyRegistered
-alreadyRegistered.heading = alreadyRegistered
+alreadyRegistered.title = Your account is already registered for this IOSS intermediary scheme
+alreadyRegistered.heading = Your account is already registered for this IOSS intermediary scheme
+alreadyRegistered.continue = Continue to your account

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -251,7 +251,7 @@ contactDetails.iossWarning = Any changes you make here will also update the cont
 
 alreadyRegistered.title = Your account is already registered for this IOSS intermediary scheme
 alreadyRegistered.heading = Your account is already registered for this IOSS intermediary scheme
-alreadyRegistered.continue = Continue to your account
+alreadyRegistered.link = <a id="backToYourAccount" class="govuk-link">Continue to your account</a>
 
 cannotRegisterNotNiBasedBusiness.title = You cannot register for this service
 cannotRegisterNotNiBasedBusiness.heading = You cannot register for this service

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -252,3 +252,6 @@ contactDetails.iossWarning = Any changes you make here will also update the cont
 alreadyRegistered.title = Your account is already registered for this IOSS intermediary scheme
 alreadyRegistered.heading = Your account is already registered for this IOSS intermediary scheme
 alreadyRegistered.continue = Continue to your account
+
+cannotRegisterNotNiBasedBusiness.title = cannotRegisterNotNiBasedBusiness
+cannotRegisterNotNiBasedBusiness.heading = cannotRegisterNotNiBasedBusiness

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -256,3 +256,6 @@ alreadyRegistered.continue = Continue to your account
 cannotRegisterNotNiBasedBusiness.title = You cannot register for this service
 cannotRegisterNotNiBasedBusiness.heading = You cannot register for this service
 cannotRegisterNotNiBasedBusiness.p1 = To register as a Northern Ireland intermediary, your business trading address must be in Northern Ireland.
+
+expiredVrnDate.title = expiredVrnDate
+expiredVrnDate.heading = expiredVrnDate

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -253,5 +253,6 @@ alreadyRegistered.title = Your account is already registered for this IOSS inter
 alreadyRegistered.heading = Your account is already registered for this IOSS intermediary scheme
 alreadyRegistered.continue = Continue to your account
 
-cannotRegisterNotNiBasedBusiness.title = cannotRegisterNotNiBasedBusiness
-cannotRegisterNotNiBasedBusiness.heading = cannotRegisterNotNiBasedBusiness
+cannotRegisterNotNiBasedBusiness.title = You cannot register for this service
+cannotRegisterNotNiBasedBusiness.heading = You cannot register for this service
+cannotRegisterNotNiBasedBusiness.p1 = To register as a Northern Ireland intermediary, your business trading address must be in Northern Ireland.

--- a/test-utils/generators/ModelGenerators.scala
+++ b/test-utils/generators/ModelGenerators.scala
@@ -430,7 +430,8 @@ trait ModelGenerators {
           registrationDate = registrationDate,
           organisationName = Some(organisationName),
           individualName = Some(individualName),
-          singleMarketIndicator = singleMarketIndicator
+          singleMarketIndicator = singleMarketIndicator,
+          deregistrationDecisionDate = None
         )
       }
     }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -100,6 +100,7 @@ trait SpecBase
         bind[AuthenticatedDataRetrievalAction].toInstance(new FakeAuthenticatedDataRetrievalAction(userAnswers, vrn)),
         bind[AuthenticatedDataRequiredActionImpl].toInstance(FakeAuthenticatedDataRequiredAction(userAnswers)),
         bind[UnauthenticatedDataRetrievalAction].toInstance(new FakeUnauthenticatedDataRetrievalAction(userAnswers)),
+        bind[CheckRegistrationFilter].toInstance(new FakeCheckRegistrationFilter()),
         bind[Clock].toInstance(clockToBind)
       )
   }

--- a/test/base/SpecBase.scala
+++ b/test/base/SpecBase.scala
@@ -79,7 +79,8 @@ trait SpecBase
       desAddress = arbitraryDesAddress.arbitrary.sample.value,
       organisationName = Some("Company name"),
       individualName = None,
-      singleMarketIndicator = true
+      singleMarketIndicator = true,
+      deregistrationDecisionDate = None
     )
 
   protected def applicationBuilder(

--- a/test/controllers/AlreadyRegisteredControllerSpec.scala
+++ b/test/controllers/AlreadyRegisteredControllerSpec.scala
@@ -27,7 +27,7 @@ class AlreadyRegisteredControllerSpec extends SpecBase {
 
     "must return OK and the correct view for a GET" in {
 
-      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswersWithVatInfo)).build()
 
       running(application) {
         val request = FakeRequest(GET, routes.AlreadyRegisteredController.onPageLoad().url)

--- a/test/controllers/AlreadyRegisteredControllerSpec.scala
+++ b/test/controllers/AlreadyRegisteredControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -20,8 +36,8 @@ class AlreadyRegisteredControllerSpec extends SpecBase {
 
         val view = application.injector.instanceOf[AlreadyRegisteredView]
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, messages(application)).toString
+        status(result) mustBe OK
+        contentAsString(result) mustBe view()(request, messages(application)).toString
       }
     }
   }

--- a/test/controllers/AlreadyRegisteredControllerSpec.scala
+++ b/test/controllers/AlreadyRegisteredControllerSpec.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.AlreadyRegisteredView
+
+class AlreadyRegisteredControllerSpec extends SpecBase {
+
+  "AlreadyRegistered Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.AlreadyRegisteredController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[AlreadyRegisteredView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/CannotRegisterNotNiBasedBusinessControllerSpec.scala
+++ b/test/controllers/CannotRegisterNotNiBasedBusinessControllerSpec.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.CannotRegisterNotNiBasedBusinessView
+
+class CannotRegisterNotNiBasedBusinessControllerSpec extends SpecBase {
+
+  "CannotRegisterNotNiBasedBusiness Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[CannotRegisterNotNiBasedBusinessView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/CannotRegisterNotNiBasedBusinessControllerSpec.scala
+++ b/test/controllers/CannotRegisterNotNiBasedBusinessControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -14,14 +30,14 @@ class CannotRegisterNotNiBasedBusinessControllerSpec extends SpecBase {
       val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
 
       running(application) {
-        val request = FakeRequest(GET, routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url)
+        val request = FakeRequest(GET, routes.CannotRegisterNotNiBasedBusinessController.onPageLoad(waypoints).url)
 
         val result = route(application, request).value
 
         val view = application.injector.instanceOf[CannotRegisterNotNiBasedBusinessView]
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, messages(application)).toString
+        status(result) mustBe OK
+        contentAsString(result) mustBe view()(request, messages(application)).toString
       }
     }
   }

--- a/test/controllers/ExpiredVrnDateControllerSpec.scala
+++ b/test/controllers/ExpiredVrnDateControllerSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers
 
 import base.SpecBase
@@ -20,8 +36,8 @@ class ExpiredVrnDateControllerSpec extends SpecBase {
 
         val view = application.injector.instanceOf[ExpiredVrnDateView]
 
-        status(result) mustEqual OK
-        contentAsString(result) mustEqual view()(request, messages(application)).toString
+        status(result) mustBe OK
+        contentAsString(result) mustBe view()(request, messages(application)).toString
       }
     }
   }

--- a/test/controllers/ExpiredVrnDateControllerSpec.scala
+++ b/test/controllers/ExpiredVrnDateControllerSpec.scala
@@ -1,0 +1,28 @@
+package controllers
+
+import base.SpecBase
+import play.api.test.FakeRequest
+import play.api.test.Helpers._
+import views.html.ExpiredVrnDateView
+
+class ExpiredVrnDateControllerSpec extends SpecBase {
+
+  "ExpiredVrnDate Controller" - {
+
+    "must return OK and the correct view for a GET" in {
+
+      val application = applicationBuilder(userAnswers = Some(emptyUserAnswers)).build()
+
+      running(application) {
+        val request = FakeRequest(GET, routes.ExpiredVrnDateController.onPageLoad().url)
+
+        val result = route(application, request).value
+
+        val view = application.injector.instanceOf[ExpiredVrnDateView]
+
+        status(result) mustEqual OK
+        contentAsString(result) mustEqual view()(request, messages(application)).toString
+      }
+    }
+  }
+}

--- a/test/controllers/actions/CheckRegistrationFilterSpec.scala
+++ b/test/controllers/actions/CheckRegistrationFilterSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import base.SpecBase
+import config.FrontendAppConfig
+import controllers.routes
+import models.requests.AuthenticatedIdentifierRequest
+import play.api.mvc.Result
+import play.api.mvc.Results.Redirect
+import play.api.test.FakeRequest
+import play.api.test.Helpers.running
+import uk.gov.hmrc.auth.core.{Enrolment, Enrolments}
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
+
+class CheckRegistrationFilterSpec extends SpecBase {
+
+  private val intermediaryEnrolmentKey = "HMRC-IOSS-INT"
+  private val enrolment: Enrolment = Enrolment(intermediaryEnrolmentKey, Seq.empty, "test", None)
+
+  class Harness(config: FrontendAppConfig) extends CheckRegistrationFilter(config){
+    def callFilter[A](request: AuthenticatedIdentifierRequest[A]): Future[Option[Result]] =
+      filter(request)
+  }
+
+  ".filter" - {
+
+    "must redirect to Already Registered Controller when an existing Intermediary enrolment is found" in {
+
+      val app = applicationBuilder(None).build()
+
+      running(app) {
+        val config = app.injector.instanceOf[FrontendAppConfig]
+        val request = AuthenticatedIdentifierRequest(FakeRequest(), testCredentials, vrn, Enrolments(Set(enrolment)), None, 1, None, None)
+        val controller = new Harness(config)
+
+        val result = controller.callFilter(request).futureValue
+
+        result mustBe Some(Redirect(routes.AlreadyRegisteredController.onPageLoad().url))
+      }
+
+    }
+
+    "must return None when an existing Intermediary enrolment is not found" in {
+
+      val app = applicationBuilder(None).build()
+
+      running(app) {
+        val config = app.injector.instanceOf[FrontendAppConfig]
+        val request = AuthenticatedIdentifierRequest(FakeRequest(), testCredentials, vrn, Enrolments(Set.empty), None, 1, None, None)
+        val controller = new Harness(config)
+
+        val result = controller.callFilter(request).futureValue
+
+        result mustBe None
+      }
+    }
+  }
+}

--- a/test/controllers/actions/FakeCheckRegistrationFilter.scala
+++ b/test/controllers/actions/FakeCheckRegistrationFilter.scala
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2025 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import config.FrontendAppConfig
+import models.requests.AuthenticatedIdentifierRequest
+import org.scalatestplus.mockito.MockitoSugar.mock
+import play.api.mvc.Result
+import utils.FutureSyntax.FutureOps
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class FakeCheckRegistrationFilter extends CheckRegistrationFilter(mock[FrontendAppConfig]) {
+  
+  override protected def filter[A](request: AuthenticatedIdentifierRequest[A]): Future[Option[Result]] =
+    None.toFuture
+}

--- a/test/controllers/auth/AuthControllerSpec.scala
+++ b/test/controllers/auth/AuthControllerSpec.scala
@@ -108,7 +108,8 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
                 desAddress = niDesAddress,
                 organisationName = Some("Company name"),
                 individualName = None,
-                singleMarketIndicator = true
+                singleMarketIndicator = true,
+                deregistrationDecisionDate = None
               )
 
             val userAnswersWithNiVatInfo: UserAnswers = emptyUserAnswers.copy(vatInfo = Some(niVatInfoController))

--- a/test/controllers/auth/AuthControllerSpec.scala
+++ b/test/controllers/auth/AuthControllerSpec.scala
@@ -21,7 +21,8 @@ import config.FrontendAppConfig
 import connectors.RegistrationConnector
 import controllers.auth.routes as authRoutes
 import models.checkVatDetails.VatApiCallResult
-import models.responses
+import models.domain.VatCustomerInfo
+import models.{DesAddress, UserAnswers, responses}
 import models.responses.NotFound
 import org.mockito.ArgumentMatchers.{any, eq as eqTo}
 import org.mockito.Mockito.*
@@ -38,6 +39,7 @@ import utils.FutureSyntax.FutureOps
 import views.html.auth.{InsufficientEnrolmentsView, UnsupportedAffinityGroupView, UnsupportedAuthProviderView, UnsupportedCredentialRoleView}
 
 import java.net.URLEncoder
+import java.time.LocalDate
 
 class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterEach {
 
@@ -90,6 +92,51 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
                 bind[AuthenticatedUserAnswersRepository].toInstance(mockAuthenticatedUserAnswersRepository)
               ).build()
 
+            val niDesAddress: DesAddress = DesAddress(
+              "1 The Street",
+              Some("Some Town"),
+              None,
+              None,
+              None,
+              Some("BT11 1AA"),
+              "GB"
+            )
+
+            val niVatInfoController: VatCustomerInfo =
+              VatCustomerInfo(
+                registrationDate = LocalDate.now(stubClockAtArbitraryDate),
+                desAddress = niDesAddress,
+                organisationName = Some("Company name"),
+                individualName = None,
+                singleMarketIndicator = true
+              )
+
+            val userAnswersWithNiVatInfo: UserAnswers = emptyUserAnswers.copy(vatInfo = Some(niVatInfoController))
+
+            when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(niVatInfoController).toFuture
+            when(mockAuthenticatedUserAnswersRepository.set(any())) thenReturn true.toFuture
+
+            running(application) {
+
+              val request = FakeRequest(GET, authRoutes.AuthController.onSignIn().url)
+              val result = route(application, request).value
+
+              val expectedAnswers = userAnswersWithNiVatInfo.set(VatApiCallResultQuery, VatApiCallResult.Success).success.value
+
+              status(result) `mustBe` SEE_OTHER
+              redirectLocation(result).value `mustBe` CheckVatDetailsPage.route(waypoints).url
+              verify(mockAuthenticatedUserAnswersRepository, times(1)).set(eqTo(expectedAnswers))
+            }
+          }
+
+          "must redirect to the Cannot Register Not NI Based Business page" in {
+
+            val application = applicationBuilder(Some(emptyUserAnswers))
+              .overrides(
+                bind[RegistrationConnector].toInstance(mockRegistrationConnector),
+                bind[AuthenticatedUserAnswersRepository].toInstance(mockAuthenticatedUserAnswersRepository)
+              ).build()
+
             when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(vatCustomerInfo).toFuture
             when(mockAuthenticatedUserAnswersRepository.set(any())) thenReturn true.toFuture
 
@@ -98,13 +145,12 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
               val request = FakeRequest(GET, authRoutes.AuthController.onSignIn().url)
               val result = route(application, request).value
 
-              val expectedAnswers = emptyUserAnswersWithVatInfo.set(VatApiCallResultQuery, VatApiCallResult.Success).success.value
-
               status(result) `mustBe` SEE_OTHER
-              redirectLocation(result).value `mustBe` CheckVatDetailsPage.route(waypoints).url
-              verify(mockAuthenticatedUserAnswersRepository, times(1)).set(eqTo(expectedAnswers))
+              redirectLocation(result).value mustEqual controllers.routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url
+              verifyNoInteractions(mockAuthenticatedUserAnswersRepository)
             }
           }
+
         }
 
         "and we cannot find their VAT details" - {

--- a/test/controllers/auth/AuthControllerSpec.scala
+++ b/test/controllers/auth/AuthControllerSpec.scala
@@ -29,6 +29,7 @@ import org.mockito.Mockito.*
 import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import pages.checkVatDetails.{CheckVatDetailsPage, VatApiDownPage}
+import pages.filters.BusinessBasedInNiOrEuPage
 import play.api.inject.bind
 import play.api.test.FakeRequest
 import play.api.test.Helpers.*
@@ -84,6 +85,28 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
 
         "and we can find their VAT details" - {
 
+          val niDesAddress: DesAddress = DesAddress(
+            "1 The Street",
+            Some("Some Town"),
+            None,
+            None,
+            None,
+            Some("BT11 1AA"),
+            "GB"
+          )
+
+          val niVatInfo: VatCustomerInfo =
+            VatCustomerInfo(
+              registrationDate = LocalDate.now(stubClockAtArbitraryDate),
+              desAddress = niDesAddress,
+              organisationName = Some("Company name"),
+              individualName = None,
+              singleMarketIndicator = true,
+              deregistrationDecisionDate = None
+            )
+
+          val userAnswersWithNiVatInfo: UserAnswers = emptyUserAnswers.copy(vatInfo = Some(niVatInfo))
+
           "must create user answers with their VAT details, then redirect to the next page" in {
 
             val application = applicationBuilder(Some(emptyUserAnswers))
@@ -92,29 +115,7 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
                 bind[AuthenticatedUserAnswersRepository].toInstance(mockAuthenticatedUserAnswersRepository)
               ).build()
 
-            val niDesAddress: DesAddress = DesAddress(
-              "1 The Street",
-              Some("Some Town"),
-              None,
-              None,
-              None,
-              Some("BT11 1AA"),
-              "GB"
-            )
-
-            val niVatInfoController: VatCustomerInfo =
-              VatCustomerInfo(
-                registrationDate = LocalDate.now(stubClockAtArbitraryDate),
-                desAddress = niDesAddress,
-                organisationName = Some("Company name"),
-                individualName = None,
-                singleMarketIndicator = true,
-                deregistrationDecisionDate = None
-              )
-
-            val userAnswersWithNiVatInfo: UserAnswers = emptyUserAnswers.copy(vatInfo = Some(niVatInfoController))
-
-            when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(niVatInfoController).toFuture
+            when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(niVatInfo).toFuture
             when(mockAuthenticatedUserAnswersRepository.set(any())) thenReturn true.toFuture
 
             running(application) {
@@ -149,6 +150,70 @@ class AuthControllerSpec extends SpecBase with MockitoSugar with BeforeAndAfterE
               status(result) `mustBe` SEE_OTHER
               redirectLocation(result).value mustEqual controllers.routes.CannotRegisterNotNiBasedBusinessController.onPageLoad().url
               verifyNoInteractions(mockAuthenticatedUserAnswersRepository)
+            }
+          }
+
+          "and the de-registration date is today or before" - {
+
+            "must redirect to Expired Vrn Date page" in {
+
+              val application = applicationBuilder(Some(emptyUserAnswers))
+                .overrides(
+                  bind[RegistrationConnector].toInstance(mockRegistrationConnector),
+                  bind[AuthenticatedUserAnswersRepository].toInstance(mockAuthenticatedUserAnswersRepository)
+                )
+                .build()
+              val expiredVrnVatInfo = vatCustomerInfo.copy(deregistrationDecisionDate = Some(LocalDate.now(stubClockAtArbitraryDate)))
+
+              when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(expiredVrnVatInfo).toFuture
+              when(mockAuthenticatedUserAnswersRepository.set(any())) thenReturn false.toFuture
+
+              running(application) {
+
+                val request = FakeRequest(GET, authRoutes.AuthController.onSignIn().url)
+                val result = route(application, request).value
+
+                status(result) mustBe SEE_OTHER
+
+                redirectLocation(result).value mustEqual controllers.routes.ExpiredVrnDateController.onPageLoad(waypoints).url
+                verifyNoInteractions(mockAuthenticatedUserAnswersRepository)
+              }
+            }
+          }
+
+          "and the de-registration date is later than today" - {
+
+            "must create user answers with their VAT details, then redirect to the next page" in {
+
+              val answers = userAnswersWithNiVatInfo.set(BusinessBasedInNiOrEuPage, true).success.value
+              val application = applicationBuilder(Some(answers))
+                .overrides(
+                  bind[RegistrationConnector].toInstance(mockRegistrationConnector),
+                  bind[AuthenticatedUserAnswersRepository].toInstance(mockAuthenticatedUserAnswersRepository)
+                )
+                .build()
+
+              val nonExpiredVrnVatInfo = niVatInfo.copy(
+                singleMarketIndicator = true,
+                deregistrationDecisionDate = Some(LocalDate.now(stubClockAtArbitraryDate).plusDays(1))
+              )
+
+              when(mockRegistrationConnector.getVatCustomerInfo()(any())) thenReturn Right(nonExpiredVrnVatInfo).toFuture
+              when(mockAuthenticatedUserAnswersRepository.set(any())) thenReturn true.toFuture
+
+              running(application) {
+
+                val request = FakeRequest(GET, authRoutes.AuthController.onSignIn().url)
+                val result = route(application, request).value
+
+                val expectedAnswers = emptyUserAnswersWithVatInfo.copy(vatInfo = Some(nonExpiredVrnVatInfo))
+                  .set(BusinessBasedInNiOrEuPage, true).success.value
+                  .set(VatApiCallResultQuery, VatApiCallResult.Success).success.value
+
+                status(result) mustBe SEE_OTHER
+                redirectLocation(result).value mustBe CheckVatDetailsPage.route(waypoints).url
+                verify(mockAuthenticatedUserAnswersRepository, times(1)).set(eqTo(expectedAnswers))
+              }
             }
           }
 

--- a/test/models/domain/VatCustomerInfoSpec.scala
+++ b/test/models/domain/VatCustomerInfoSpec.scala
@@ -55,7 +55,8 @@ class VatCustomerInfoSpec extends SpecBase {
         registrationDate = vatCustomerInfo.registrationDate,
         organisationName = None,
         individualName = None,
-        singleMarketIndicator = vatCustomerInfo.singleMarketIndicator
+        singleMarketIndicator = vatCustomerInfo.singleMarketIndicator,
+        deregistrationDecisionDate = None
       )
 
       Json.toJson(expectedResult) mustBe json


### PR DESCRIPTION
This PR aims to build 4 kick out pages based on different scenarios, as follows:

1. [Intermediary is already registered](https://ioss-intermediaries-prototype-3634dc150b34.herokuapp.com/1-0/registration/gg-kickout-already-registered.html)
2. [Intermediary doesn't have a NI address](https://ioss-intermediaries-prototype-3634dc150b34.herokuapp.com/1-0/registration/gg-kickout-no-ni-address)
3. [Intermediary has a VRN end date that is 'today' or earlier (in the past)](https://ioss-intermediaries-prototype-3634dc150b34.herokuapp.com/1-0/registration/gg-kickout-vrn-end-date-passed)
4. [Intermediary is not VAT registered](https://ioss-intermediaries-prototype-3634dc150b34.herokuapp.com/1-0/registration/gg-kickout-not-vat-registered)